### PR TITLE
Blot Improvements

### DIFF
--- a/src/blots/mention.js
+++ b/src/blots/mention.js
@@ -1,6 +1,5 @@
 const Embed = Quill.import('blots/embed');
 
-
 class MentionBlot extends Embed {
   static create(data) {
     const node = super.create();
@@ -13,7 +12,15 @@ class MentionBlot extends Embed {
     node.dataset.value = data.value;
     return node;
   }
+
+  static value(domNode) {
+    return {
+      id: domNode.dataset.id,
+      value: domNode.dataset.value
+    }
+  }
 }
+
 MentionBlot.blotName = 'mention';
 MentionBlot.tagName = 'MENTION';
 

--- a/src/blots/mention.js
+++ b/src/blots/mention.js
@@ -22,6 +22,7 @@ class MentionBlot extends Embed {
 }
 
 MentionBlot.blotName = 'mention';
-MentionBlot.tagName = 'MENTION';
+MentionBlot.tagName = 'span';
+MentionBlot.className = 'mention';
 
 Quill.register(MentionBlot);


### PR DESCRIPTION
Thanks so much for creating this plugin. I've been struggling to try to get something working, but this is mostly working for me now.

I did run into a couple of small problems that I fixed with this PR.

The first is the value of the Blot. This is what Quill saves in the Delta, which is what I'm saving to the database and not the output HTML. It previously just had:

```js
{
  insert: {
    mention: true
  }
}
```

Now, it returns the id and value:

```js
{
  insert: {
    mention: {
      id: 1,
      value: 'Fredrik Sundqvist'
    }
  }
}
```

The second thing I fixed was the use of the non-existent mention tag. I replaced that with a span tag and className. Quill uses the className to distinguish between different blots that use the same tag.
