### PR TITLE
Added a new option to allow for isolating the denotation character

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ const quill = new Quill('#editor', {
 | `offsetTop`          | `2`            | Additional top offset of the mention container position |
 | `offsetLeft`         | `0`            | Additional left offset of the mention container position |
 | `mentionDenotationChars` | `["@"]`    | Specifies which characters will cause the mention autocomplete to open
+| `isolateCharacter`   | `false`        | Whether or not the denotation character(s) should be isolated. For example, to avoid mentioning in an email.
 
 
 ## Authors

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -25,6 +25,7 @@ class Mention {
       maxChars: 31,
       offsetTop: 2,
       offsetLeft: 0,
+      isolateCharacter: false,
     };
 
     Object.assign(this.options, options);
@@ -233,6 +234,10 @@ class Mention {
       return mentionIndex > previousIndex ? mentionIndex : previousIndex;
     }, -1);
     if (mentionCharIndex > -1) {
+      if (this.options.isolateCharacter && !(mentionCharIndex == 0 || !!beforeCursorPos[mentionCharIndex - 1].match(/\s/g))) {
+        this.hideMentionList();
+        return;
+      }
       const mentionCharPos = this.cursorPos - (beforeCursorPos.length - mentionCharIndex);
       this.mentionCharPos = mentionCharPos;
       const textAfter = beforeCursorPos.substring(mentionCharIndex + 1);


### PR DESCRIPTION
This library is almost perfect for our use case, but we noticed that email addresses trigger the mention list when the denotation character is '@', so we've made a small change to allow a new option that won't trigger the mention list unless the denotation character is isolated.

Now doesn't include any formatting changes, my bad.

