### PR TITLE
Adding hover state to mention list items, tweaking scroll behavior

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,6 +33,11 @@
     .ql-editor:focus {
       border: 1px solid #025FAE;
     }
+
+    .ql-mention-list-container {
+      max-height: 300px;
+      overflow: auto;
+    }
   </style>
   <!-- Initialize Quill editor -->
   <script>

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -112,13 +112,13 @@ class Mention {
     this.isOpen = false;
   }
 
-  highlightItem(scrollItemToTop = true) {
+  highlightItem(scrollItemInView = true) {
     for (let i = 0; i < this.mentionList.childNodes.length; i += 1) {
       this.mentionList.childNodes[i].classList.remove('selected');
     }
     this.mentionList.childNodes[this.itemIndex].classList.add('selected');
 
-    if (scrollItemToTop) {
+    if (scrollItemInView) {
       const itemHeight = this.mentionList.childNodes[this.itemIndex].offsetHeight;
       const itemPos = this.itemIndex * itemHeight;
       const containerTop = this.mentionContainer.scrollTop;


### PR DESCRIPTION
This PR should introduce hover states for list items, which were previously missing. Additionally, I tweaked the scrolling we do on keyup and keydown to keep selected items in view. Instead of scrolling the selected item to the top of the list every time, we only scroll when the user has selected an item that is out of view (via the arrow keys). Additionally, instead of scrolling that item to the top, we scroll just far enough to bring the hidden item into view, but no farther.