### PR TITLE
Adding option for fixing the mentions container to the quill container

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ const quill = new Quill('#editor', {
 | `offsetLeft`         | `0`            | Additional left offset of the mention container position |
 | `mentionDenotationChars` | `["@"]`    | Specifies which characters will cause the mention autocomplete to open
 | `isolateCharacter`   | `false`        | Whether or not the denotation character(s) should be isolated. For example, to avoid mentioning in an email.
+| `fixMentionsToQuill` | `false`        | When set to true, the mentions menu will be rendered above or below the quill container. Otherwise, the mentions menu will track the denotation character(s);
 
 
 ## Authors

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -36,7 +36,7 @@ class Mention {
     this.mentionContainer.style.cssText = 'display: none; position: absolute;';
 
     if (this.options.fixMentionsToQuill) {
-      this.mentionContainer.style.width = 'inherit';
+      this.mentionContainer.style.width = 'auto';
     }
 
     this.mentionList = document.createElement('ul');

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -192,6 +192,10 @@ class Mention {
   }
 
   containerRightIsNotVisible(leftPos) {
+    if (this.options.fixMentionsToQuill) {
+      return false;
+    }
+
     const rightPos = leftPos + this.mentionContainer.offsetWidth;
     const browserWidth = window.pageXOffset + document.documentElement.clientWidth;
     return rightPos > browserWidth;

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -26,6 +26,7 @@ class Mention {
       offsetTop: 2,
       offsetLeft: 0,
       isolateCharacter: false,
+      fixMentionsToQuill: false,
     };
 
     Object.assign(this.options, options);
@@ -33,6 +34,10 @@ class Mention {
     this.mentionContainer = document.createElement('div');
     this.mentionContainer.className = 'ql-mention-list-container';
     this.mentionContainer.style.cssText = 'display: none; position: absolute;';
+
+    if (this.options.fixMentionsToQuill) {
+      this.mentionContainer.style.width = 'inherit';
+    }
 
     this.mentionList = document.createElement('ul');
     this.mentionList.className = 'ql-mention-list';
@@ -197,27 +202,41 @@ class Mention {
     const mentionCharPos = this.quill.getBounds(this.mentionCharPos);
 
     let topPos = window.pageYOffset +
-      containerPos.top +
-      mentionCharPos.bottom +
       this.options.offsetTop;
 
     let leftPos = window.pageXOffset +
       containerPos.left +
-      mentionCharPos.left +
       this.options.offsetLeft;
 
+    if (this.options.fixMentionsToQuill) {
+      topPos += containerPos.bottom;
+      const rightPos = window.outerWidth - containerPos.right;
+      this.mentionContainer.style.right = `${rightPos}px`;
+    } else {
+      leftPos += mentionCharPos.left;
+      topPos += containerPos.top + mentionCharPos.bottom;
+    }
+
     if (this.containerBottomIsNotVisible(topPos)) {
-      const overMentionCharPos = window.pageYOffset + containerPos.top + mentionCharPos.top;
       const containerHeight = this.mentionContainer.offsetHeight + this.options.offsetTop;
+      let overMentionCharPos = window.pageYOffset + containerPos.top;
+
+      if (!this.options.fixMentionsToQuill) {
+        overMentionCharPos += mentionCharPos.top;
+      }
+
       topPos = overMentionCharPos - containerHeight;
     }
+
     if (this.containerRightIsNotVisible(leftPos)) {
       const containerWidth = this.mentionContainer.offsetWidth + this.options.offsetLeft;
       const browserWidth = window.pageXOffset + document.documentElement.clientWidth;
       leftPos = browserWidth - containerWidth;
     }
+
     this.mentionContainer.style.top = `${topPos}px`;
     this.mentionContainer.style.left = `${leftPos}px`;
+
     this.mentionContainer.style.visibility = 'visible';
   }
 


### PR DESCRIPTION
Adding a new option that allows for the mentions container to be fixed to the quill container instead of following the mention character