### PR TITLE
Add optional anchor links to mentions

### DIFF
--- a/src/blots/mention.js
+++ b/src/blots/mention.js
@@ -14,8 +14,8 @@ class MentionBlot extends Embed {
     node.dataset.id = data.id;
     node.dataset.value = data.value;
     node.dataset.denotationChar = data.denotationChar;
-    if (data.anchor) {
-      node.dataset.anchor = data.anchor;
+    if (data.link) {
+      node.dataset.link = data.link;
     }
     return node;
   }
@@ -24,7 +24,7 @@ class MentionBlot extends Embed {
     return {
       id: domNode.dataset.id,
       value: domNode.dataset.value,
-      anchor: domNode.dataset.anchor || null,
+      link: domNode.dataset.link || null,
       denotationChar: domNode.dataset.denotationChar,
     };
   }

--- a/src/blots/mention.js
+++ b/src/blots/mention.js
@@ -14,6 +14,9 @@ class MentionBlot extends Embed {
     node.dataset.id = data.id;
     node.dataset.value = data.value;
     node.dataset.denotationChar = data.denotationChar;
+    if (data.anchor) {
+      node.dataset.anchor = data.anchor;
+    }
     return node;
   }
 
@@ -21,6 +24,7 @@ class MentionBlot extends Embed {
     return {
       id: domNode.dataset.id,
       value: domNode.dataset.value,
+      anchor: domNode.dataset.anchor || null,
       denotationChar: domNode.dataset.denotationChar,
     };
   }

--- a/src/index.html
+++ b/src/index.html
@@ -42,14 +42,14 @@
   <!-- Initialize Quill editor -->
   <script>
     const atValues = [
-      { "id": "5a97b2a402de91c5b6c3e8a4", "value": "Josie Rice", "anchor": "http://www.josierice.com" },
-      { "id": "5a97b2a464a8ff2d0996d2ef", "value": "Elva Bowman", "anchor": "mailto:elva@bowman.com" },
-      { "id": "5a97b2a4ecb768a2092a298b", "value": "Ella Cochran", "anchor": "http://www.ellacochran.com" },
-      { "id": "5a97b2a418b984d2aff97657", "value": "Knowles Walls", "anchor": "mailto:knowles@walls.com" },
-      { "id": "5a97b2a4436c2c9acc6b5ad0", "value": "Hanson Webb", "anchor": "http://www.hansonwebb.com" },
-      { "id": "5a97b2a4436c2c9acc6b5ad1", "value": "Maria Cruz", "anchor": "mailto:maria@cruz.com" },
-      { "id": "5a97b2a4436c2c9acc6b5ad2", "value": "Pablo Escobar", "anchor": "http://www.pabloescobar.com" },
-      { "id": "5a97b2a4436c2c9acc6b5ad3", "value": "Richard Smith", "anchor": "mailto:richard@smith.com" }
+      { "id": "5a97b2a402de91c5b6c3e8a4", "value": "Josie Rice", "link": "http://www.josierice.com" },
+      { "id": "5a97b2a464a8ff2d0996d2ef", "value": "Elva Bowman", "link": "mailto:elva@bowman.com" },
+      { "id": "5a97b2a4ecb768a2092a298b", "value": "Ella Cochran", "link": "http://www.ellacochran.com" },
+      { "id": "5a97b2a418b984d2aff97657", "value": "Knowles Walls", "link": "mailto:knowles@walls.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad0", "value": "Hanson Webb", "link": "http://www.hansonwebb.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad1", "value": "Maria Cruz", "link": "mailto:maria@cruz.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad2", "value": "Pablo Escobar", "link": "http://www.pabloescobar.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad3", "value": "Richard Smith", "link": "mailto:richard@smith.com" }
     ];
 
     const hashValues = [

--- a/src/index.html
+++ b/src/index.html
@@ -42,14 +42,14 @@
   <!-- Initialize Quill editor -->
   <script>
     const atValues = [
-      { "id": "5a97b2a402de91c5b6c3e8a4", "value": "Josie Rice" },
-      { "id": "5a97b2a464a8ff2d0996d2ef", "value": "Elva Bowman" },
-      { "id": "5a97b2a4ecb768a2092a298b", "value": "Ella Cochran" },
-      { "id": "5a97b2a418b984d2aff97657", "value": "Knowles Walls" },
-      { "id": "5a97b2a4436c2c9acc6b5ad0", "value": "Hanson Webb" },
-      { "id": "5a97b2a4436c2c9acc6b5ad1", "value": "Maria Cruz" },
-      { "id": "5a97b2a4436c2c9acc6b5ad2", "value": "Pablo Escobar" },
-      { "id": "5a97b2a4436c2c9acc6b5ad3", "value": "Richard Smith" }
+      { "id": "5a97b2a402de91c5b6c3e8a4", "value": "Josie Rice", "anchor": "http://www.josierice.com" },
+      { "id": "5a97b2a464a8ff2d0996d2ef", "value": "Elva Bowman", "anchor": "mailto:elva@bowman.com" },
+      { "id": "5a97b2a4ecb768a2092a298b", "value": "Ella Cochran", "anchor": "http://www.ellacochran.com" },
+      { "id": "5a97b2a418b984d2aff97657", "value": "Knowles Walls", "anchor": "mailto:knowles@walls.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad0", "value": "Hanson Webb", "anchor": "http://www.hansonwebb.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad1", "value": "Maria Cruz", "anchor": "mailto:maria@cruz.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad2", "value": "Pablo Escobar", "anchor": "http://www.pabloescobar.com" },
+      { "id": "5a97b2a4436c2c9acc6b5ad3", "value": "Richard Smith", "anchor": "mailto:richard@smith.com" }
     ];
 
     const hashValues = [

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -140,13 +140,13 @@ class Mention {
   }
 
   getItemData() {
-    const itemAnchor = this.mentionList.childNodes[this.itemIndex].dataset.anchor;
+    const itemLink = this.mentionList.childNodes[this.itemIndex].dataset.link;
     return {
       id: this.mentionList.childNodes[this.itemIndex].dataset.id,
-      value: itemAnchor ?
-        `<a href="${itemAnchor}" target="_blank">${this.mentionList.childNodes[this.itemIndex].dataset.value}` :
+      value: itemLink ?
+        `<a href="${itemLink}" target="_blank">${this.mentionList.childNodes[this.itemIndex].dataset.value}` :
         this.mentionList.childNodes[this.itemIndex].dataset.value,
-      anchor: itemAnchor || null,
+      link: itemLink || null,
       denotationChar: this.mentionList.childNodes[this.itemIndex].dataset.denotationChar,
     };
   }
@@ -197,8 +197,8 @@ class Mention {
         li.dataset.id = data[i].id;
         li.dataset.value = data[i].value;
         li.dataset.denotationChar = mentionChar;
-        if (data[i].anchor) {
-          li.dataset.anchor = data[i].anchor;
+        if (data[i].link) {
+          li.dataset.link = data[i].link;
         }
         li.innerHTML = this.options.renderItem(data[i], searchTerm);
         li.onmouseenter = this.onItemMouseEnter.bind(this);

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -140,9 +140,13 @@ class Mention {
   }
 
   getItemData() {
+    const itemAnchor = this.mentionList.childNodes[this.itemIndex].dataset.anchor;
     return {
       id: this.mentionList.childNodes[this.itemIndex].dataset.id,
-      value: this.mentionList.childNodes[this.itemIndex].dataset.value,
+      value: itemAnchor ?
+        `<a href="${itemAnchor}" target="_blank">${this.mentionList.childNodes[this.itemIndex].dataset.value}` :
+        this.mentionList.childNodes[this.itemIndex].dataset.value,
+      anchor: itemAnchor || null,
       denotationChar: this.mentionList.childNodes[this.itemIndex].dataset.denotationChar,
     };
   }
@@ -193,6 +197,9 @@ class Mention {
         li.dataset.id = data[i].id;
         li.dataset.value = data[i].value;
         li.dataset.denotationChar = mentionChar;
+        if (data[i].anchor) {
+          li.dataset.anchor = data[i].anchor;
+        }
         li.innerHTML = this.options.renderItem(data[i], searchTerm);
         li.onmouseenter = this.onItemMouseEnter.bind(this);
         li.onclick = this.onItemClick.bind(this);


### PR DESCRIPTION
This PR introduces the `anchor` property as optional.

Example:
```
{
  "id": "5a97b2a402de91c5b6c3e8a4",
  "value": "Josie Rice",
  "anchor": "www.josierice.com";
}
```
![image](https://user-images.githubusercontent.com/29824163/46909272-ec3ce500-cf05-11e8-96d0-f93e4c20f6c0.png)
