### PR TITLE
Fix: Mention placement position

### DIFF
--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -191,11 +191,14 @@ class Mention {
     if (!this.options.showDenotationChar) {
       render.denotationChar = '';
     }
+
+    const prevMentionCharPos = this.mentionCharPos;
+
     this.quill
       .deleteText(this.mentionCharPos, this.cursorPos - this.mentionCharPos, Quill.sources.USER);
-    this.quill.insertEmbed(this.mentionCharPos, 'mention', render, Quill.sources.USER);
-    this.quill.insertText(this.mentionCharPos + 1, ' ', Quill.sources.USER);
-    this.quill.setSelection(this.mentionCharPos + 2, Quill.sources.USER);
+    this.quill.insertEmbed(prevMentionCharPos, 'mention', render, Quill.sources.USER);
+    this.quill.insertText(prevMentionCharPos + 1, ' ', Quill.sources.USER);
+    this.quill.setSelection(prevMentionCharPos + 2, Quill.sources.USER);
     this.hideMentionList();
   }
 


### PR DESCRIPTION
when using multiple @ at different locations without "isolateCharacter" option enabled and using keyboard to select the options from the dropdown, the editor was placing mentions span in wrong location, because somehow the current location was changing for only this procedure, so a small fix I did is to store the location beforehand deleting excess characters and supplied that location to accompanying functions. 