### PR TITLE
Make possible to don't insert space after mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ const quill = new Quill('#editor', {
 | `listItemClass` |  `'ql-mention-list-item'` | Style class to be used for list items (may be null)
 | `mentionContainerClass` |  `'ql-mention-list-container'` |  Style class to be used for the mention list container (may be null)
 | `mentionListClass` |  `'ql-mention-list'` |  Style class to be used for the mention list (may be null)
+| `spaceAfterInsert`   | `true`        | Whether or not insert 1 space after mention block in text
 
 ### Styling
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -134,6 +134,7 @@
           allowedChars: /^[A-Za-z\sÅÄÖåäö]*$/,
           mentionDenotationChars: ["@", "#"],
           dataAttributes: ['myCustomProperty'],
+          spaceAfterInsert: true,
           source: function (searchTerm, renderList, mentionChar) {
             let values;
 

--- a/src/quill.mention.css
+++ b/src/quill.mention.css
@@ -34,6 +34,7 @@
   border-radius: 6px;
   background-color: #D3E1EB;
   padding: 3px 0;
+  margin-right: 2px;
 }
 
 .mention>span {

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -46,6 +46,7 @@ class Mention {
       listItemClass: 'ql-mention-list-item',
       mentionContainerClass: 'ql-mention-list-container',
       mentionListClass: 'ql-mention-list',
+      spaceAfterInsert: true,
     };
 
     Object.assign(this.options, options, {
@@ -197,8 +198,13 @@ class Mention {
     this.quill
       .deleteText(this.mentionCharPos, this.cursorPos - this.mentionCharPos, Quill.sources.USER);
     this.quill.insertEmbed(prevMentionCharPos, 'mention', render, Quill.sources.USER);
-    this.quill.insertText(prevMentionCharPos + 1, ' ', Quill.sources.USER);
-    this.quill.setSelection(prevMentionCharPos + 2, Quill.sources.USER);
+    if (this.options.spaceAfterInsert) {
+      this.quill.insertText(prevMentionCharPos + 1, ' ', Quill.sources.USER);
+      // setSelection here sets cursor position
+      this.quill.setSelection(prevMentionCharPos + 2, Quill.sources.USER);
+    } else {
+      this.quill.setSelection(prevMentionCharPos + 1, Quill.sources.USER);
+    }
     this.hideMentionList();
   }
 


### PR DESCRIPTION
Currently quill-mention always inserts 1 space after mention block. This PR allows to control this behavior via new option: `spaceAfterInsert`.

Add small margin-right to the mention block, cause without it with current styles and with `spaceAfterInsert = false` mention block looks to close to the next char. It's completely backward compatible change, as default behavior was not changed. 

implements #15