### PR TITLE
Fix MentionBlot display

### DIFF
--- a/src/blots/mention.ts
+++ b/src/blots/mention.ts
@@ -58,7 +58,10 @@ class MentionBlot extends Embed {
     if (typeof this.render === "function") {
       node.appendChild(this.render(data));
     } else {
-      node.innerHTML += data.value;
+      const mentionValue = document.createElement("span");
+      mentionValue.className = "ql-mention-value";
+      mentionValue.innerText = data.value;
+      node.appendChild(mentionValue);
     }
 
     return MentionBlot.setDataValues(node, data);

--- a/src/blots/mention.ts
+++ b/src/blots/mention.ts
@@ -58,7 +58,7 @@ class MentionBlot extends Embed {
     if (typeof this.render === "function") {
       node.appendChild(this.render(data));
     } else {
-      node.innerText += data.value;
+      node.innerHTML += data.value;
     }
 
     return MentionBlot.setDataValues(node, data);


### PR DESCRIPTION
Change `innerText` to `innerHTML` to avoid flattening the `denotationChar` span. This retains the className for ql-mention-denotation-char so that it's style-able